### PR TITLE
Allows more relaxed formats for refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add empty line after task list output. (#6)
+- Allow more relaxed formats for refs. (#7)
 
 ## 2.0 - 20 Aug 2019
 

--- a/src/Refs.hs
+++ b/src/Refs.hs
@@ -62,7 +62,7 @@ replaceRefs text refMap = L.foldl expandRef text (extractRefs text)
         Nothing -> t
 
 refMatcher :: String
-refMatcher = "[A-Z]+#[0-9A-Za-z]+"
+refMatcher = "[[:graph:]]+#[[:graph:]]+"
 
 buildRefUrl :: Ref -> UrlTemplate -> Text
 buildRefUrl ref urlTemplate =

--- a/test/RefsSpec.hs
+++ b/test/RefsSpec.hs
@@ -12,9 +12,9 @@ spec =
   describe "Refs" $ do
     describe "extracting refs" $
       it "finds all tokens" $ do
-        let text = "Fix issues in CORE#123 and SERVER#456"
+        let text = "Fix issues in MAIN-CORE#123-31 and SERVER#456"
         let expectedRefs =
-              [ Refs.Ref "CORE" "123" "CORE#123"
+              [ Refs.Ref "MAIN-CORE" "123-31" "MAIN-CORE#123-31"
               , Refs.Ref "SERVER" "456" "SERVER#456"
               ]
         Refs.extractRefs text `shouldBe` expectedRefs


### PR DESCRIPTION
Can use digits and URL-safe symbols both for service and id.