### PR TITLE
Add structured makefile to organise dev/ci tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ jobs:
             - today-v3-{{ checksum "stack.yaml" }}
       - run:
           name: Resolve/Update Dependencies
-          command: stack --no-terminal setup
+          command: make ci.setup
       - run:
-          name: Run tests
-          command: stack --no-terminal test
+          name: Run unit tests
+          command: make ci.test-unit
       - run:
           name: Install executable
-          command: stack --no-terminal install
+          command: make ci.install
       - save_cache:
           name: Cache Dependencies
           key: today-v3-{{ checksum "stack.yaml" }}-{{ checksum "package.yaml" }}
@@ -33,17 +33,11 @@ jobs:
       - image: fpco/stack-build-small:lts
     steps:
       - checkout
-      - run:
-          name: Install Bats
-          command: |
-            git clone https://github.com/bats-core/bats-core.git
-            cd bats-core
-            ./install.sh /usr/local
       - attach_workspace:
           at: ~/.local
       - run:
-          name: Integration tests
-          command: bats test/
+          name: Run Integration tests
+          command: make ci.test-integration
       - store_artifacts:
           path: ~/.local/bin/today
           destination: today

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,79 @@
+SYSTEM := $(shell sh -c 'uname -s 2>/dev/null')
+STACK_LOCAL_BIN_PATH := $(shell stack path | grep 'local-bin-path' | awk ' { print $$2 }')
+
+# EXECUTABLE AND MAN PAGES
+
+SOURCE_EXE = $(STACK_LOCAL_BIN_PATH)/today
 TARGET_EXE = /usr/local/bin/today
 TARGET_MAN = /usr/local/share/man/man1/today.1
-
-STACK_LOCAL_BIN_PATH := $(shell stack path | grep 'local-bin-path' | awk ' { print $$2 }')
-SOURCE_EXE = $(STACK_LOCAL_BIN_PATH)/today
 
 install: $(TARGET_MAN)
 .PHONY: install
 
-$(TARGET_EXE):
-	stack install
-	cp $(SOURCE_EXE) $(TARGET_EXE)
+$(TARGET_EXE): $(SOURCE_EXE)
+	cp $< $@
 .PHONY: $(TARGET_EXE)
 
-$(TARGET_MAN): $(TARGET_EXE)
-	echo $@
+$(TARGET_MAN): help2man $(TARGET_EXE)
 	help2man --no-info $(TARGET_EXE) > $(TARGET_MAN)
 .PHONY: $(TARGET_MAN)
+
+$(SOURCE_EXE):
+	stack install
+.PHONY: $(SOURCE_EXE)
+
+# TESTS
+
+test: test-unit test-integration
+
+test-unit:
+	stack test
+.PHONY: test-unit
+
+test-integration: bats
+	bats test
+.PHONY: test-integration
+
+# CI
+
+ci.test: ci.test-unit ci.test-integration
+
+ci.test-unit:
+	stack --no-terminal test
+.PHONY: ci.test-unit
+
+ci.test-integration: bats
+	bats -t test
+.PHONY: ci.test-integration
+
+ci.setup:
+	stack --no-terminal setup
+.PHONY: ci.setup
+
+ci.install:
+	stack --no-terminal install
+.phony: ci.install
+
+#################################################################
+############################# TOOLS #############################
+#################################################################
+
+bats:
+ifeq ($(SYSTEM),Darwin)
+ifneq ($(shell bats --version >/dev/null 2>&1 ; echo $$?),0)
+	brew install bats-core
+endif
+else
+	git clone https://github.com/bats-core/bats-core.git /tmp/bats
+	cd /tmp/bats && ./install.sh /usr/local
+	rm -rf /tmp/bats
+endif
+
+help2man:
+ifeq ($(SYSTEM),Darwin)
+ifneq ($(shell help2man --version >/dev/null 2>&1 ; echo $$?),0)
+	brew install help2man
+endif
+else
+	apt-get install --yes help2man
+endif


### PR DESCRIPTION
- Capture setup of additional tools required for dev (e.g. `bats` for integration testing and `help2man` for man pages generation).
- Explicit CI targets to abstract details from CI config file.