### PR TITLE
Include blank lines inside in/out reporters to improve readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.3 - 30 Aug 2019
+
+- Include blank lines inside in/out reporters to improve readability. (#11)
+
 ## 2.0.2 - 23 Aug 2019
 
 - Add linebreak after in/out output. (#9)

--- a/src/Ui.hs
+++ b/src/Ui.hs
@@ -160,12 +160,13 @@ instance Render TodayScope where
 instance Render Today where
   render (Today scope tasks refMap)
     | Map.null tasks = "No tasks available"
-    | otherwise = render scope <$$> vsep (map todayLine (Map.toList tasks))
+    | otherwise =
+      render scope <$$> hardline <+> vsep (map todayLine (Map.toList tasks))
     where
       todayLine (_id, t) =
         "•" <+>
         render (StatusLabel (Tasks.status t)) <+>
-        text (Text.unpack $ Refs.replaceRefs (Tasks.text t) refMap)
+        text (Text.unpack $ Refs.replaceRefs (Tasks.text t) refMap) <+> hardline
 
 refList :: Refs.RefMap -> Doc
 refList refMap = hardline <+> indent 1 content <+> hardline


### PR DESCRIPTION
Resulting format in Slack is more readable.